### PR TITLE
Gather throwers from all exception table entries

### DIFF
--- a/jacodb-api/src/main/kotlin/org/jacodb/api/Classes.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/Classes.kt
@@ -87,7 +87,7 @@ interface JcMethod : JcSymbol, JcAnnotatedSymbol, JcAccessible {
     val signature: String?
     val parameters: List<JcParameter>
 
-    val exceptions: List<JcClassOrInterface>
+    val exceptions: List<TypeName>
 
     fun asmNode(): MethodNode
     fun flowGraph(): JcGraph

--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcInst.kt
@@ -153,6 +153,7 @@ class JcThrowInst(
 class JcCatchInst(
     location: JcInstLocation,
     val throwable: JcValue,
+    val throwableTypes: List<JcType>,
     val throwers: List<JcInstRef>
 ) : AbstractJcInst(location) {
     override val operands: List<JcExpr>

--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
@@ -146,17 +146,22 @@ class JcRawThrowInst(
     }
 }
 
+data class JcRawCatchEntry(
+    val acceptedThrowable: TypeName,
+    val startInclusive: JcRawLabelRef,
+    val endExclusive: JcRawLabelRef
+)
+
 class JcRawCatchInst(
     override val owner: JcMethod,
     val throwable: JcRawValue,
     val handler: JcRawLabelRef,
-    val startInclusive: JcRawLabelRef,
-    val endExclusive: JcRawLabelRef
+    val entries: List<JcRawCatchEntry>,
 ) : JcRawInst {
     override val operands: List<JcRawExpr>
         get() = listOf(throwable)
 
-    override fun toString(): String = "catch ($throwable: ${throwable.typeName}) $startInclusive - $endExclusive"
+    override fun toString(): String = "catch ($throwable: ${throwable.typeName})"
 
     override fun <T> accept(visitor: JcRawInstVisitor<T>): T {
         return visitor.visitJcRawCatchInst(this)

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/analysis/impl/StringConcatSimplifier.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/analysis/impl/StringConcatSimplifier.kt
@@ -144,6 +144,7 @@ class StringConcatSimplifier(val jcGraph: JcGraph) : DefaultJcInstVisitor<JcInst
     override fun visitJcCatchInst(inst: JcCatchInst): JcInst = JcCatchInst(
         inst.location,
         inst.throwable,
+        inst.throwableTypes,
         inst.throwers.flatMap { indicesOf(it) }
     )
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/bytecode/JcMethodImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/bytecode/JcMethodImpl.kt
@@ -22,16 +22,13 @@ import org.jacodb.api.JcClassOrInterface
 import org.jacodb.api.JcMethod
 import org.jacodb.api.JcMethodExtFeature
 import org.jacodb.api.JcParameter
+import org.jacodb.api.TypeName
 import org.jacodb.api.cfg.JcInst
 import org.jacodb.api.cfg.JcInstList
 import org.jacodb.api.cfg.JcRawInst
-import org.jacodb.api.ext.findClass
 import org.jacodb.impl.fs.fullAsmNode
 import org.jacodb.impl.types.MethodInfo
 import org.jacodb.impl.types.TypeNameImpl
-import org.jacodb.impl.types.signature.JvmClassRefType
-import org.jacodb.impl.types.signature.MethodResolutionImpl
-import org.jacodb.impl.types.signature.MethodSignature
 import org.objectweb.asm.tree.MethodNode
 
 class JcMethodImpl(
@@ -46,19 +43,9 @@ class JcMethodImpl(
     override val signature: String? get() = methodInfo.signature
     override val returnType = TypeNameImpl(methodInfo.returnClass)
 
-    private val methodSignature = MethodSignature.of(this)
-
-    override val exceptions: List<JcClassOrInterface>
+    override val exceptions: List<TypeName>
         get() {
-            if (methodSignature is MethodResolutionImpl) {
-                val classpath = enclosingClass.classpath
-                return methodSignature.exceptionTypes.mapNotNull {
-                    (it as? JvmClassRefType)?.let {
-                        classpath.findClass(it.name)
-                    }
-                }
-            }
-            return emptyList()
+            return methodInfo.exceptions.map { TypeNameImpl(it) }
         }
 
     override val declaration = JcDeclarationImpl.of(location = enclosingClass.declaration.location, this)

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/GraphExt.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/GraphExt.kt
@@ -224,6 +224,8 @@ fun JcBlockGraph.toFile(dotCmd: String, file: File? = null): Path {
 open class JcExceptionResolver(val classpath: JcClasspath) : DefaultJcExprVisitor<List<JcClassType>>,
     DefaultJcInstVisitor<List<JcClassType>> {
     private val throwableType = classpath.findTypeOrNull<Throwable>() as JcClassType
+    private val errorType = classpath.findTypeOrNull<Error>() as JcClassType
+    private val runtimeExceptionType = classpath.findTypeOrNull<RuntimeException>() as JcClassType
     private val nullPointerExceptionType = classpath.findTypeOrNull<NullPointerException>() as JcClassType
     private val arithmeticExceptionType = classpath.findTypeOrNull<ArithmeticException>() as JcClassType
 
@@ -278,7 +280,8 @@ open class JcExceptionResolver(val classpath: JcClasspath) : DefaultJcExprVisito
 
     override fun visitJcLambdaExpr(expr: JcLambdaExpr): List<JcClassType> {
         return buildList {
-            add(throwableType)
+            add(runtimeExceptionType)
+            add(errorType)
             addAll(expr.method.exceptions.thisOrThrowable())
         }
     }
@@ -289,23 +292,24 @@ open class JcExceptionResolver(val classpath: JcClasspath) : DefaultJcExprVisito
 
     override fun visitJcVirtualCallExpr(expr: JcVirtualCallExpr): List<JcClassType> {
         return buildList {
-            add(throwableType)
-            add(nullPointerExceptionType)
+            add(runtimeExceptionType)
+            add(errorType)
             addAll(expr.method.exceptions.thisOrThrowable())
         }
     }
 
     override fun visitJcStaticCallExpr(expr: JcStaticCallExpr): List<JcClassType> {
         return buildList {
-            add(throwableType)
+            add(runtimeExceptionType)
+            add(errorType)
             addAll(expr.method.exceptions.thisOrThrowable())
         }
     }
 
     override fun visitJcSpecialCallExpr(expr: JcSpecialCallExpr): List<JcClassType> {
         return buildList {
-            add(throwableType)
-            add(nullPointerExceptionType)
+            add(runtimeExceptionType)
+            add(errorType)
             addAll(expr.method.exceptions.thisOrThrowable())
         }
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcGraphBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcGraphBuilder.kt
@@ -265,10 +265,12 @@ class JcGraphBuilder(
     }
 
     override fun visitJcRawCatchInst(inst: JcRawCatchInst): JcInst = handle(inst) {
-        val throwers = run {
+        val location = newLocation()
+        val throwableTypes = inst.entries.map { it.acceptedThrowable.asType }
+        val throwers = inst.entries.flatMap {
             val result = mutableListOf<JcInstRef>()
-            var current = instList.indexOf(labels.getValue(inst.startInclusive))
-            val end = instList.indexOf(labels.getValue(inst.endExclusive))
+            var current = instList.indexOf(labels.getValue(it.startInclusive))
+            val end = instList.indexOf(labels.getValue(it.endExclusive))
             while (current != end) {
                 val rawInst = instList[current]
                 if (rawInst != inst) {
@@ -280,10 +282,12 @@ class JcGraphBuilder(
                 ++current
             }
             result
-        }
+        }.distinct()
+
         return JcCatchInst(
-            newLocation(),
+            location,
             inst.throwable.accept(this) as JcValue,
+            throwableTypes,
             throwers
         )
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/MethodNodeBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/MethodNodeBuilder.kt
@@ -188,7 +188,7 @@ class MethodNodeBuilder(
                 if (it.access == Opcodes.ACC_PUBLIC) 0 else it.access
             )
         }
-        mn.exceptions = method.exceptions.map { it.name.typeName().jvmClassName }
+        mn.exceptions = method.exceptions.map { it.jvmClassName }
         mn.instructions = currentInsnList
         mn.tryCatchBlocks = tryCatchNodeList
         mn.maxLocals = localIndex
@@ -327,12 +327,14 @@ class MethodNodeBuilder(
     }
 
     override fun visitJcRawCatchInst(inst: JcRawCatchInst) {
-        tryCatchNodeList += TryCatchBlockNode(
-            label(inst.startInclusive),
-            label(inst.endExclusive),
-            label(inst.handler),
-            inst.throwable.typeName.internalDesc
-        )
+        tryCatchNodeList += inst.entries.map {
+            TryCatchBlockNode(
+                label(it.startInclusive),
+                label(it.endExclusive),
+                label(inst.handler),
+                it.acceptedThrowable.internalDesc
+            )
+        }
         updateStackInfo(1)
         currentInsnList.add(storeValue(inst.throwable))
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
@@ -40,6 +40,7 @@ import org.jacodb.api.cfg.JcRawArrayAccess
 import org.jacodb.api.cfg.JcRawAssignInst
 import org.jacodb.api.cfg.JcRawCallInst
 import org.jacodb.api.cfg.JcRawCastExpr
+import org.jacodb.api.cfg.JcRawCatchEntry
 import org.jacodb.api.cfg.JcRawCatchInst
 import org.jacodb.api.cfg.JcRawClassConstant
 import org.jacodb.api.cfg.JcRawCmpExpr
@@ -229,6 +230,11 @@ private val AbstractInsnNode.isTerminateInst
     get() = this is InsnNode && (this.opcode == Opcodes.ATHROW || this.opcode in Opcodes.IRETURN..Opcodes.RETURN)
 
 private val TryCatchBlockNode.typeOrDefault get() = this.type ?: THROWABLE_CLASS
+
+private val Collection<TryCatchBlockNode>.commonTypeOrDefault get() = map { it.type }
+    .distinct()
+    .singleOrNull()
+    ?: THROWABLE_CLASS
 
 class RawInstListBuilder(
     val method: JcMethod,
@@ -989,29 +995,36 @@ class RawInstListBuilder(
             else -> error("Unknown frame node type: ${insnNode.type}")
         }
 
-        when (val catch = methodNode.tryCatchBlocks.firstOrNull { it.handler == currentEntry }) {
-            null -> {
-                currentFrame = Frame(
-                    lastFrameState.locals.copyLocals(predecessorFrames).toPersistentMap(),
-                    lastFrameState.stack.copyStack(predecessorFrames).toPersistentList()
+        val catchEntries = methodNode.tryCatchBlocks.filter { it.handler == currentEntry }
+
+        if (catchEntries.isEmpty()) {
+            currentFrame = Frame(
+                lastFrameState.locals.copyLocals(predecessorFrames).toPersistentMap(),
+                lastFrameState.stack.copyStack(predecessorFrames).toPersistentList()
+            )
+        } else {
+            currentFrame = Frame(
+                lastFrameState.locals.copyLocals(predecessorFrames).toPersistentMap(),
+                persistentListOf()
+            )
+
+            val throwable = nextRegister(catchEntries.commonTypeOrDefault.typeName())
+            val entries = catchEntries.map {
+                JcRawCatchEntry(
+                    it.typeOrDefault.typeName(),
+                    labelRef(it.start),
+                    labelRef(it.end)
                 )
             }
 
-            else -> {
-                currentFrame = Frame(
-                    lastFrameState.locals.copyLocals(predecessorFrames).toPersistentMap(),
-                    persistentListOf()
-                )
-                val throwable = nextRegister(catch.typeOrDefault.typeName())
-                instructionList(insnNode) += JcRawCatchInst(
+            instructionList(insnNode) += JcRawCatchInst(
                     method,
-                    throwable,
-                    labelRef(catch.handler),
-                    labelRef(catch.start),
-                    labelRef(catch.end)
-                )
-                push(throwable)
-            }
+                throwable,
+                labelRef(currentEntry),
+                entries
+            )
+
+            push(throwable)
         }
     }
 
@@ -1157,11 +1170,11 @@ class RawInstListBuilder(
         if (predecessors.size == predecessorFrames.size) {
             currentFrame = mergeFrames(predecessors.zip(predecessorFrames).toMap())
         }
-        when (val tryCatch = methodNode.tryCatchBlocks.firstOrNull { it.handler == insnNode }) {
-            null -> {}
-            else -> {
-                push(nextRegister(tryCatch.typeOrDefault.typeName()))
-            }
+
+        val catchEntries = methodNode.tryCatchBlocks.filter { it.handler == insnNode }
+
+        if (catchEntries.isNotEmpty()) {
+            push(nextRegister(catchEntries.commonTypeOrDefault.typeName()))
         }
     }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/ExprMapper.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/ExprMapper.kt
@@ -149,7 +149,7 @@ class ExprMapper(val mapping: Map<JcRawExpr, JcRawExpr>) : JcRawInstVisitor<JcRa
         val newThrowable = inst.throwable.accept(this) as JcRawValue
         return when (inst.throwable) {
             newThrowable -> inst
-            else -> JcRawCatchInst(inst.owner, newThrowable, inst.handler, inst.startInclusive, inst.endExclusive)
+            else -> JcRawCatchInst(inst.owner, newThrowable, inst.handler, inst.entries)
         }
     }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/virtual/JcVirtualMethod.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/virtual/JcVirtualMethod.kt
@@ -95,7 +95,7 @@ open class JcVirtualMethodImpl(
     override val annotations: List<JcAnnotation>
         get() = emptyList()
 
-    override val exceptions: List<JcClassOrInterface>
+    override val exceptions: List<TypeName>
         get() = emptyList()
 
     override fun bind(clazz: JcClassOrInterface) {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeConverter.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeConverter.kt
@@ -111,6 +111,7 @@ private fun MethodNode.asMethodInfo(): MethodInfo {
         desc = desc,
         access = access,
         annotations = visibleAnnotations.asAnnotationInfos(true) + invisibleAnnotations.asAnnotationInfos(false),
+        exceptions = exceptions.map { it.className },
         parametersInfo = List(params.size) { index ->
             ParameterInfo(
                 index = index,

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/types/JcTypedMethodImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/types/JcTypedMethodImpl.kt
@@ -23,6 +23,7 @@ import org.jacodb.api.JcTypeVariableDeclaration
 import org.jacodb.api.JcTypedMethod
 import org.jacodb.api.JcTypedMethodParameter
 import org.jacodb.api.MethodResolution
+import org.jacodb.api.ext.findTypeOrNull
 import org.jacodb.api.ext.isNullable
 import org.jacodb.api.throwClassNotFound
 import org.jacodb.impl.types.signature.FieldResolutionImpl
@@ -77,9 +78,12 @@ class JcTypedMethodImpl(
 
     override val exceptions: List<JcRefType>
         get() {
-            val impl = info.impl ?: return emptyList()
-            return impl.exceptionTypes.map {
+            val typesFromSignature = info.impl?.exceptionTypes?.map {
                 classpath.typeOf(info.substitutor.substitute(it)) as JcRefType
+            } ?: emptyList()
+
+            return typesFromSignature.ifEmpty {
+                method.exceptions.map { classpath.findTypeOrNull(it) as JcRefType }
             }
         }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/types/Objects.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/types/Objects.kt
@@ -69,6 +69,7 @@ class MethodInfo(
     val signature: String?,
     val access: Int,
     val annotations: List<AnnotationInfo>,
+    val exceptions: List<String>,
     val parametersInfo: List<ParameterInfo>,
 ) {
     val returnClass: String get() = Type.getReturnType(desc).className

--- a/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/IRExamples.java
+++ b/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/IRExamples.java
@@ -17,6 +17,7 @@
 package org.jacodb.testing.cfg;
 
 import java.io.*;
+import java.net.DatagramSocket;
 
 public class IRExamples {
     int x;
@@ -110,6 +111,13 @@ public class IRExamples {
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputName))) {
         } catch (IOException e) {
+        }
+    }
+
+    static public void multiCatch(DatagramSocket s) {
+        try {
+            s.receive(null);
+        } catch (IOException | IllegalStateException e) {
         }
     }
 


### PR DESCRIPTION
* Support multiple throwable types for JcCatchInst

* Use MethodNode for exceptions in JcMethod and JcTypedMethod