### PR TITLE
Support CFG for Java bytecode < 1.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlinVersion=1.7.21
 coroutinesVersion=1.6.4
 collectionsVersion=0.3.5
 kmetadataVersion=0.5.0
-asmVersion=9.3
+asmVersion=9.5
 jooqVersion=3.14.16
 junit5Version=5.9.0
 

--- a/jacodb-core/build.gradle.kts
+++ b/jacodb-core/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
 
     implementation(group = "com.google.guava", name = "guava", version = "31.1-jre")
     implementation(group = "org.jetbrains.kotlinx", name = "kotlinx-metadata-jvm", version = kmetadataVersion)
+    testImplementation(group = "javax.activation", name = "activation", version = "1.1")
+    testImplementation(group = "javax.mail", name = "mail", version = "1.4.7")
 
     testFixturesImplementation(project(":jacodb-api"))
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
@@ -71,6 +71,7 @@ import org.jacodb.api.cfg.JcRawNegExpr
 import org.jacodb.api.cfg.JcRawNeqExpr
 import org.jacodb.api.cfg.JcRawNewArrayExpr
 import org.jacodb.api.cfg.JcRawNewExpr
+import org.jacodb.api.cfg.JcRawNullConstant
 import org.jacodb.api.cfg.JcRawOrExpr
 import org.jacodb.api.cfg.JcRawRemExpr
 import org.jacodb.api.cfg.JcRawReturnInst
@@ -426,7 +427,7 @@ class RawInstListBuilder(
     private fun local(variable: Int, expr: JcRawValue, insn: AbstractInsnNode): JcRawAssignInst? {
         val oldVar = currentFrame.locals[variable]
         return if (oldVar != null) {
-            if (oldVar.typeName == expr.typeName) {
+            if (oldVar.typeName == expr.typeName || expr is JcRawNullConstant) {
                 JcRawAssignInst(method, oldVar, expr)
             } else if (expr is JcRawSimpleValue) {
                 currentFrame = currentFrame.put(variable, expr)
@@ -1152,7 +1153,7 @@ class RawInstListBuilder(
     private fun buildLabelNode(insnNode: LabelNode) {
         val labelInst = label(insnNode)
         instructionList(insnNode) += labelInst
-        val predecessors = predecessors.getOrDefault(insnNode, emptySet())
+        val predecessors = predecessors.getOrDefault(insnNode, emptySet()).filter {it !is LabelNode}
         val predecessorFrames = predecessors.mapNotNull { frames[it] }
         if (predecessors.size == predecessorFrames.size) {
             currentFrame = mergeFrames(predecessors.zip(predecessorFrames).toMap())

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/Simplifier.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/Simplifier.kt
@@ -234,7 +234,7 @@ internal class Simplifier {
                     inst.lhv as JcRawLocalVar,
                     ::mutableSetOf
                 ) += jcClasspath.findTypeOrNull(inst.rhv.typeName.typeName)
-                    ?: error("Could not find type")
+                    ?: error("Could not find type ${inst.rhv.typeName.typeName}")
             }
         }
         val replacement = types.filterValues { it.size > 1 }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/ClasspathCache.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/ClasspathCache.kt
@@ -123,7 +123,7 @@ private class JcGraphHolder(private val methodRef: JcMethodRef) {
     }
 
     val rawInstList: JcInstList<JcRawInst> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        val list: JcInstList<JcRawInst> = RawInstListBuilder(method, method.asmNode().jsrInlined).build()
+        val list: JcInstList<JcRawInst> = RawInstListBuilder(method, method.asmNode()).build()
         methodFeatures.fold(list) { value, feature ->
             feature.transformRawInstList(method, value)
         }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeConverter.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeConverter.kt
@@ -21,6 +21,7 @@ import org.jacodb.api.ClassSource
 import org.jacodb.api.JcClasspath
 import org.jacodb.impl.bytecode.computeFrames
 import org.jacodb.impl.bytecode.hasFrameInfo
+import org.jacodb.impl.bytecode.inlineJsrs
 import org.jacodb.impl.storage.AnnotationValueKind
 import org.jacodb.impl.types.AnnotationInfo
 import org.jacodb.impl.types.AnnotationValue
@@ -140,7 +141,9 @@ val ClassSource.info: ClassInfo
 
 val ClassSource.fullAsmNode: ClassNode
     get() {
-        return newClassNode(ClassReader.EXPAND_FRAMES)
+        return newClassNode(ClassReader.EXPAND_FRAMES).also {
+            it.inlineJsrs()
+        }
     }
 
 fun ClassSource.fullAsmNodeWithFrames(classpath: JcClasspath): ClassNode {

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InstructionsTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InstructionsTest.kt
@@ -16,6 +16,7 @@
 
 package org.jacodb.testing.cfg
 
+import com.sun.mail.iap.Protocol
 import com.sun.mail.imap.IMAPMessage
 import kotlinx.coroutines.runBlocking
 import org.jacodb.api.JcClassOrInterface
@@ -58,6 +59,21 @@ class InstructionsTest : BaseTest() {
     fun `null ref test`() {
         val clazz = cp.findClass<DataHandler>()
         clazz.declaredMethods.first { it.name == "writeTo" }.flowGraph()
+    }
+
+    @Test
+    fun `Protocol test`() {
+        val clazz = cp.findClass("com.sun.mail.pop3.Protocol")
+        val method = clazz.declaredMethods.first { it.name == "<init>" }
+        method.flowGraph()
+    }
+
+    @Test
+    fun `SMTPSaslAuthenticator test`() {
+        val clazz = cp.findClass("com.sun.mail.smtp.SMTPSaslAuthenticator")
+        val method = clazz.declaredMethods.first { it.name == "authenticate" }
+        println(method.dumpInstructions())
+        method.flowGraph()
     }
 
     @Test


### PR DESCRIPTION
As an example one could take one of:

- java.mail jar
-  javax.activation jar
and tried to build graphs based on this classes


There are two cases which were not covered:

- instructions which predecessors have no entry point this frames for them are not computed
- instructions which predecessors may be after current instruction and as a result have no calculated frames at current moment