### PR TITLE
Type inference for negation

### DIFF
--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
@@ -798,7 +798,10 @@ class RawInstListBuilder(
     private fun buildUnary(insn: InsnNode) {
         val operand = pop()
         val expr = when (val opcode = insn.opcode) {
-            in Opcodes.INEG..Opcodes.DNEG -> JcRawNegExpr(operand.typeName, operand)
+            in Opcodes.INEG..Opcodes.DNEG -> {
+                val resolvedType = maxOfPrimitiveTypes(operand.typeName.typeName, PredefinedPrimitives.Int)
+                JcRawNegExpr(TypeNameImpl(resolvedType), operand)
+            }
             Opcodes.ARRAYLENGTH -> JcRawLengthExpr(PredefinedPrimitives.Int.typeName(), operand)
             else -> error("Unknown unary opcode $opcode")
         }

--- a/jacodb-core/src/testFixtures/java/org/jacodb/testing/primitives/Primitives.java
+++ b/jacodb-core/src/testFixtures/java/org/jacodb/testing/primitives/Primitives.java
@@ -37,4 +37,24 @@ public class Primitives {
     public int example(char s, char c) {
         return s + c;
     }
+
+    public int unaryExample(char a) {
+        return -a;
+    }
+
+    public int unaryExample(byte a) {
+        return -a;
+    }
+
+    public int unaryExample(short a) {
+        return -a;
+    }
+
+    public long unaryExample(long a) {
+        return -a;
+    }
+
+    public float unaryExample(float a) {
+        return -a;
+    }
 }


### PR DESCRIPTION
Also found similar problem as #105 for `Opcodes.INEG..Opcodes.DNEG`, so the PR fixes it.