### PR TITLE
Field descriptors fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -269,6 +269,11 @@ fun MavenPublication.addPom() {
                 email.set("azat.aam@gmail.com")
             }
             developer {
+                id.set("sergeypospelov")
+                name.set("Sergey Pospelov")
+                email.set("sergeypospelov59@gmail.com")
+            }
+            developer {
                 id.set("UnitTestBot")
                 name.set("UnitTestBot Team")
             }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcInstListBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcInstListBuilder.kt
@@ -305,8 +305,7 @@ class JcInstListBuilder(val method: JcMethod,val instList: JcInstList<JcRawInst>
         JcLocalVar(value.name, value.typeName.asType())
 
     override fun visitJcRawFieldRef(value: JcRawFieldRef): JcExpr {
-        val instance = value.instance?.accept(this) as? JcValue
-        val klass = (instance?.type ?: value.declaringClass.asType()) as JcClassType
+        val klass = value.declaringClass.asType() as JcClassType
         val field = klass.findFieldOrNull(value.fieldName)
             ?: throw IllegalStateException("${klass.typeName}#${value.fieldName} not found")
         return JcFieldRef(value.instance?.accept(this) as? JcValue, field)

--- a/jacodb-core/src/testFixtures/java/org/jacodb/testing/structure/FieldsAndMethods.java
+++ b/jacodb-core/src/testFixtures/java/org/jacodb/testing/structure/FieldsAndMethods.java
@@ -23,9 +23,18 @@ public class FieldsAndMethods {
     public static class Common1Child extends Common.Common1 {
         private int privateFieldsAndMethods;
 
+        private boolean publicField;
+
         private void privateFieldsAndMethods() {
         }
 
+        private int accessIntField() {
+            return ((Common.Common1) this).publicField;
+        }
+
+        private boolean accessBooleanField() {
+            return publicField;
+        }
     }
 
 }


### PR DESCRIPTION
Consider this example:
```java
public class HiddenFieldSuperClass {
    public int a, b;
}

class HiddenFieldSuccClass extends HiddenFieldSuperClass {
    public double b;
    public int checkSuccField(HiddenFieldSuccClass o) {
        if (b == 2.0) {
            return 2;
        }
        if (((HiddenFieldSuperClass) this).b == 3) {
            return 3;
        }
        return 4;
    }
}
```

While building IR for method `checkSuccField`, JacoDB resolves `((HiddenFieldSuperClass) this).b` to the inner field `public double b` which is incorrect. The PR fixes this problem and adds a corresponding test.